### PR TITLE
Reorder setup steps to avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 ## Installation
 1. Clone the repo and change to the directory of the project
-2. `npm install`
-3. `npm install json-server`
-4. In a terminal window run `npm start`
-5. In another terminal window run `npm run api`
-6. To start at the beginning checkout the first tag: `git checkout 01-Base`
+2. `git checkout 01-Base` to start at the beginning of the workshop
+3. `npm install`
+4. `npm install json-server`
+5. In a terminal window run `npm start`
+6. In another terminal window run `npm run api`
 
 ## Problems?
 If that doesn't work out, there are a series of code sandboxes. They do not have


### PR DESCRIPTION
I noticed while setting up that the `api` script doesn't exist on `master`, but it does exist at the `01-Base` tag. 

This PR reorders the setup steps so that users switch branches first, with the intention of avoiding confusion for users less familiar with JavaScript & NPM scripts.